### PR TITLE
fix svg rendering

### DIFF
--- a/webapp/graphite/render/glyph.py
+++ b/webapp/graphite/render/glyph.py
@@ -885,7 +885,7 @@ class Graph:
         metaData = { }
 
       self.surface.finish()
-      svgData = str(self.surfaceData.getvalue())
+      svgData = self.surfaceData.getvalue().decode('utf-8')
       self.surfaceData.close()
 
       svgData = svgData.replace('pt"', 'px"', 2) # we expect height/width in pixels, not points


### PR DESCRIPTION
Upstream fixed this in a better way (by making all of the functions operate on bytestrings instead of unistrings), but it doesn't cleanly merge because they rewrote a ton of this code. This minimal fix makes SVG rendering work again as long as you don't do anything that brings in binary data.

The core problem is that calling `str()` on a BytesIO yields a string like `b'foobar'` and Graphite doesn't handle the leading `b'` very well.